### PR TITLE
Regular maintenance

### DIFF
--- a/src/CS.Sdk/CS.Sdk.csproj
+++ b/src/CS.Sdk/CS.Sdk.csproj
@@ -26,8 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
     <PackageReference Include="Kodeistan.Hl7" Version="2.18.1" />
   </ItemGroup>
 

--- a/tests/CS.Sdk.Tests/CS.Sdk.Tests.csproj
+++ b/tests/CS.Sdk.Tests/CS.Sdk.Tests.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/CS.Sdk.Tests/messages/json/test-000.json
+++ b/tests/CS.Sdk.Tests/messages/json/test-000.json
@@ -19,13 +19,9 @@
       "race_category__code_system": "CDCREC"
     }
   ],
-  "ethnic_group": [
-    {
-      "ethnic_group": "Not Hispanic or Latino",
-      "ethnic_group__code": "2186-5",
-      "ethnic_group__code_system": "CDCREC"
-    }
-  ],
+  "ethnic_group": "Not Hispanic or Latino",
+  "ethnic_group__code": "2186-5",
+  "ethnic_group__code_system": "CDCREC",
   "country_of_birth": "UNITED STATES",
   "country_of_birth__code": "USA",
   "country_of_birth__code_system": "ISO3166_1",

--- a/tests/CS.Sdk.Tests/messages/json/test-001.json
+++ b/tests/CS.Sdk.Tests/messages/json/test-001.json
@@ -19,13 +19,9 @@
       "race_category__code_system": "CDCREC"
     }
   ],
-  "ethnic_group": [
-    {
-      "ethnic_group": "Not Hispanic or Latino",
-      "ethnic_group__code": "2186-5",
-      "ethnic_group__code_system": "CDCREC"
-    }
-  ],
+  "ethnic_group": "Not Hispanic or Latino",
+  "ethnic_group__code": "2186-5",
+  "ethnic_group__code_system": "CDCREC",
   "country_of_birth": "UNITED STATES",
   "country_of_birth__code": "USA",
   "country_of_birth__code_system": "ISO3166_1",

--- a/tests/CS.Sdk.Tests/messages/json/test-002.json
+++ b/tests/CS.Sdk.Tests/messages/json/test-002.json
@@ -19,13 +19,9 @@
       "race_category__code_system": "CDCREC"
     }
   ],
-  "ethnic_group": [
-    {
-      "ethnic_group": "Not Hispanic or Latino",
-      "ethnic_group__code": "H",
-      "ethnic_group__code_system": "CDCREC"
-    }
-  ],
+  "ethnic_group": "Not Hispanic or Latino",
+  "ethnic_group__code": "H",
+  "ethnic_group__code_system": "CDCREC",
   "country_of_birth": "UNITED STATES",
   "country_of_birth__code": "USA",
   "country_of_birth__code_system": "ISO3166_1",

--- a/tests/CS.Sdk.Tests/messages/json/test-003.json
+++ b/tests/CS.Sdk.Tests/messages/json/test-003.json
@@ -19,13 +19,9 @@
       "race_category__code_system": "CDCREC"
     }
   ],
-  "ethnic_group": [
-    {
-      "ethnic_group": "Not Hispanic or Latino",
-      "ethnic_group__code": "2186-5",
-      "ethnic_group__code_system": "CDCREC"
-    }
-  ],
+  "ethnic_group": "Not Hispanic or Latino",
+  "ethnic_group__code": "2186-5",
+  "ethnic_group__code_system": "CDCREC",
   "country_of_birth": "UNITED STATES",
   "country_of_birth__code": "USA",
   "country_of_birth__code_system": "ISO3166_1",
@@ -114,5 +110,5 @@
       "physician_name": "Smith, Jim",
       "physician_phone": "404.555.0123"
     }
-  ],
+  ]
 }

--- a/tests/CS.Sdk.Tests/messages/json/test-004.json
+++ b/tests/CS.Sdk.Tests/messages/json/test-004.json
@@ -14,16 +14,12 @@
   "subjects_sex__code": "M",
   "race_category": [
     {
-      "race_category": "White",
+      "race_category": "White"
     }
   ],
-  "ethnic_group": [
-    {
-      "ethnic_group": "Not Hispanic or Latino",
-      "ethnic_group__code": "2186-5",
-      "ethnic_group__code_system": "CDCREC"
-    }
-  ],
+  "ethnic_group": "Not Hispanic or Latino",
+  "ethnic_group__code": "2186-5",
+  "ethnic_group__code_system": "CDCREC",
   "country_of_birth": "UNITED STATES",
   "country_of_birth__code": "USA",
   "country_of_birth__code_system": "ISO3166_1",
@@ -112,5 +108,5 @@
       "physician_name": "Smith, Jim",
       "physician_phone": "404.555.0123"
     }
-  ],
+  ]
 }

--- a/tests/CS.Sdk.Tests/messages/json/test-005.json
+++ b/tests/CS.Sdk.Tests/messages/json/test-005.json
@@ -19,13 +19,9 @@
       "race_category__code_system": "CDCREC"
     }
   ],
-  "ethnic_group": [
-    {
-      "ethnic_group": "Not Hispanic or Latino",
-      "ethnic_group__code": "2186-5",
-      "ethnic_group__code_system": "CDCREC"
-    }
-  ],
+  "ethnic_group": "Not Hispanic or Latino",
+  "ethnic_group__code": "2186-5",
+  "ethnic_group__code_system": "CDCREC",
   "country_of_birth": "UNITED STATES",
   "country_of_birth__code": "USA",
   "country_of_birth__code_system": "ISO3166_1",


### PR DESCRIPTION
This pull request updates the .NET target for the test project to 8.0, the latest LTS release, and fixes a security vulnerability identified in one of the NuGet packages.

This pull request also fixes broken unit tests, which were reading JSON input files that were using an out-of-date schema. Updating the schema fixed the tests. Specifically, the new schema uses a flat structure for ethnicity while the old one assumed ethnicity could hold more than one value. In the use case were this code would have been deployed, the data producers would only be able to select one ethnicity. The use of a JSON array for ethnicity caused the validator to see the field holding the ethnicity array and assumed there should have been a corresponding __code field, and when it did not find it, it threw an error. The additional errors failed assertions made in the unit tests.